### PR TITLE
Update 2d_customPostProcessingComponent.txt

### DIFF
--- a/versioned_docs/version-2.0.4/code/2d_customPostProcessingComponent.txt
+++ b/versioned_docs/version-2.0.4/code/2d_customPostProcessingComponent.txt
@@ -1,4 +1,4 @@
-public class MyCustomPostProcessingComponent : DungeonGeneratorPostProcessingGrid2D
+public class MyCustomPostProcessingComponent : DungeonGeneratorPostProcessingComponentGrid2D
 {
     public override void Run(DungeonGeneratorLevelGrid2D level)
     {


### PR DESCRIPTION
As in documentation, when using MonoBehaviour it should inherit from DungeonGeneratorPostProcessingComponentGrid2D not DungeonGeneratorPostProcessingGrid2D.