### PR TITLE
Feat: Respect Unity gizmos settings when drawing room template settings inspector

### DIFF
--- a/Editor/RoomTemplates/RoomTemplateSettingsInspector.cs
+++ b/Editor/RoomTemplates/RoomTemplateSettingsInspector.cs
@@ -108,6 +108,21 @@ namespace Edgar.Unity.Editor
 
         private void OnSceneGUIPersistent(SceneView sceneView)
         {
+            if (!Handles.ShouldRenderGizmos())
+            {
+                return;
+            }
+            else
+            {
+#if UNITY_2022_1_OR_NEWER
+                GizmoUtility.TryGetGizmoInfo(typeof(RoomTemplateSettingsGrid2D), out GizmoInfo gizmosEnabled);
+                if (!gizmosEnabled.gizmoEnabled)
+                {
+                    return;
+                }
+#endif
+            }
+
             if (target == null || PrefabStageUtility.GetCurrentPrefabStage() == null)
             {
                 RemoveOnSceneGUIDelegate();

--- a/Editor/RoomTemplates/RoomTemplateSettingsInspector.cs
+++ b/Editor/RoomTemplates/RoomTemplateSettingsInspector.cs
@@ -115,8 +115,8 @@ namespace Edgar.Unity.Editor
             else
             {
 #if UNITY_2022_1_OR_NEWER
-                GizmoUtility.TryGetGizmoInfo(typeof(RoomTemplateSettingsGrid2D), out GizmoInfo gizmosEnabled);
-                if (!gizmosEnabled.gizmoEnabled)
+                GizmoUtility.TryGetGizmoInfo(typeof(RoomTemplateSettingsGrid2D), out GizmoInfo info);
+                if (info != null && !info.gizmoEnabled)
                 {
                     return;
                 }


### PR DESCRIPTION
### Context:
Right now, despite toggling either the entire gizmos off, or toggling gizmos off specifically for `RoomTemplateSettingsGrid2D`, the room outlines continue to draw in the editor scene view.


### Problem:
The reason this happens is because currently the outline are drawn from a [callback hooked](https://github.com/OndrejNepozitek/Edgar-Unity/blob/1f463447bdba7b8f7066c41af22e18e3caf93b31/Editor/RoomTemplates/RoomTemplateSettingsInspector.cs#L198) into Unity's `SceneView.duringSceneGui` callback, which does not respect gizmos settings.

### Solution:
To manage this, I've implemented the following checks in the `onSceneGUIPersistent` callback method:
- First check if all gizmos are turned off. If so, dont draw (return)
- Otherwise, check if gizmos are specifically turned off for this script (`RoomTemplateSettingsGrid2D`). If so, don't draw (return).
    - This check unfortunately is only possible from 2022.1 and on via the [GizmosUtility](https://docs.unity3d.com/2022.1/Documentation/ScriptReference/GizmoUtility.html). Before this version of Unity, solutions to do this [seem to be quite hacky](https://discussions.unity.com/t/toggling-gizmos-from-script/752420/10).
    
### Testing:
![test-gizmos](https://github.com/user-attachments/assets/913f55f1-df73-4ff4-bd4b-aa060290b7d0)
